### PR TITLE
README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-icm-beamer-theme
-================
+# icm-beamer-theme
 
 LaTeX Beamer theme for ICM presentations.
 
-Installation instructions:
+## Installation instructions:
 
     mkdir -p `kpsewhich -var-value TEXMFHOME`/tex/latex/beamer/
+    cd `kpsewhich -var-value TEXMFHOME`/tex/latex/beamer/
     git clone git@github.com:bolo1729/icm-beamer-theme.git
 
+See e.g. http://tex.stackexchange.com/a/120948/3754 for details and also how to
+install system-wide.


### PR DESCRIPTION
Cloning should be into the subdir of TEXMFHOME.

Added link to Stackoverflow to details and instructions of how to
install system-wide.
